### PR TITLE
Add RxJS filter sample

### DIFF
--- a/src/rxjs/filter-even-numbers-sample.ts
+++ b/src/rxjs/filter-even-numbers-sample.ts
@@ -1,0 +1,9 @@
+import { filter, from, tap } from "rxjs";
+
+from([1, 2, 3, 4, 5])
+  .pipe(
+    tap((x) => console.log(`source ${x}`)),
+    filter((x) => x % 2 === 0),
+    tap((x) => console.log(`filtered ${x}`))
+  )
+  .subscribe((x) => console.log(`result ${x}`));


### PR DESCRIPTION
## Summary
- add an example showing how to filter even numbers with RxJS

## Testing
- `pnpm build` *(fails: Cannot find module)*
- `pnpm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_685c09484e8083219a4470c1c5188e64